### PR TITLE
Use a much smaller sugar lib

### DIFF
--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -2,7 +2,7 @@
 
 var sys, JsonRpcError, ParseError, InvalidRequestError, MethodNotFoundError, InvalidParamsError;
 
-require('sugar');
+require('./sugar');
 
 sys = require('sys');
 

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -2,7 +2,7 @@
 
 var exception, jsonrpc, util;
 
-require('sugar');
+require('./sugar');
 util      = require('util');
 exception = require('./exceptions');
 

--- a/lib/sugar.js
+++ b/lib/sugar.js
@@ -1,0 +1,12 @@
+Object.prototype.isString = function(obj) {
+  return typeof(obj) == 'string';
+}
+Object.prototype.isNumber = function(obj) {
+  return typeof(obj) == 'number';
+}
+Object.prototype.isObject = function(obj) {
+  return typeof(obj) == 'object';
+}
+Object.prototype.isArray = function(obj) {
+  return Object.prototype.toString.call(obj) === '[object Array]';
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonrpc-serializer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A simple library to serialize/deserialize JSON-RPC 2.0 messages",
   "main": "lib/serializer.js",
   "scripts": {
@@ -21,9 +21,6 @@
   },
   "author": "Ruben LZ Tan",
   "license": "MIT",
-  "dependencies": {
-    "sugar": "~1.3.8"
-  },
   "devDependencies": {
     "chai": "~1.4.2",
     "mocha": "~1.8.1"


### PR DESCRIPTION
It can help use `jsonrpc-serializer` on browser side with `browserify`.

With the original `sugar` lib, the size of generated javascript file by `browserify` is 10 times larger than without.
