### PR TITLE
Allow null id for error. Updated test.

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -14,6 +14,9 @@ var isNumber = function(obj) {
 var isObject = function(obj) {
     return typeof(obj) == 'object';
 }
+var isNull = function(obj) {
+    return obj === null;
+}
 var isArray = function(obj) {
     return Object.prototype.toString.call(obj) === '[object Array]';
 }
@@ -25,6 +28,12 @@ function _validateMessageStructure(type, data) {
 
     function checkId(id) {
         if (!isString(id) && (!isNumber(id) || (isNumber(id) && id % 1 !== 0))) {
+            errors.push('An ID must be provided. It must be either a string or an integer (no fractions allowed)');
+        }
+    }
+
+    function checkErrorId(id) {
+        if (!isNull(id) && !isString(id) && (!isNumber(id) || (isNumber(id) && id % 1 !== 0))) {
             errors.push('An ID must be provided. It must be either a string or an integer (no fractions allowed)');
         }
     }
@@ -82,7 +91,7 @@ function _validateMessageStructure(type, data) {
             break;
 
         case 'error' :
-            checkId(data.id);
+            checkErrorId(data.id);
             checkError(data.error);
             break;
     }

--- a/test/serializer.test.js
+++ b/test/serializer.test.js
@@ -129,12 +129,14 @@ describe('# Serializer Test Suite', function () {
             var result3 = ser.error('id', new ser.err.InvalidRequestError());
             var result4 = ser.error('id', new ser.err.MethodNotFoundError());
             var result5 = ser.error('id', new ser.err.InvalidParamsError());
+            var result6 = ser.error(null, new ser.err.JsonRpcError('Null error'));
 
             var object1 = ser.errorObject('id', new ser.err.JsonRpcError('Crazy error'));
             var object2 = ser.errorObject('id', new ser.err.ParseError());
             var object3 = ser.errorObject('id', new ser.err.InvalidRequestError());
             var object4 = ser.errorObject('id', new ser.err.MethodNotFoundError());
             var object5 = ser.errorObject('id', new ser.err.InvalidParamsError());
+            var object6 = ser.errorObject('id', new ser.err.JsonRpcError('Null error'));
 
             it('should return a serialized string', function () {
                 result1.should.be.a('string');
@@ -142,6 +144,7 @@ describe('# Serializer Test Suite', function () {
                 result3.should.be.a('string');
                 result4.should.be.a('string');
                 result5.should.be.a('string');
+                result6.should.be.a('string');
             });
 
             it('errorObject() should return a equivalent object', function() {
@@ -150,6 +153,7 @@ describe('# Serializer Test Suite', function () {
                 JSON.parse(result3).should.eql.object3;
                 JSON.parse(result4).should.eql.object4;
                 JSON.parse(result5).should.eql.object5;
+                JSON.parse(result6).should.eql.object6;
             });
         });
     });


### PR DESCRIPTION
I've updated your validation system so that it could be possibile to create an error with null id. Useful for

rpc call with invalid JSON:
--> {"jsonrpc": "2.0", "method": "foobar, "params": "bar", "baz]
<-- {"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}

rpc call with invalid Request object:
--> {"jsonrpc": "2.0", "method": 1, "params": "bar"}
<-- {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": null}
