### PR TITLE
Switched from util.inherits to separate 'inherits' module

### DIFF
--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -1,8 +1,8 @@
 (function () { 'use strict';
 
-var util, JsonRpcError, ParseError, InvalidRequestError, MethodNotFoundError, InvalidParamsError;
+var inherits, JsonRpcError, ParseError, InvalidRequestError, MethodNotFoundError, InvalidParamsError;
 
-util = require('util');
+inherits = require('inherits');
 
 // Add a serialize() method to the prototype chain to ensure that the
 // serialization happens properly
@@ -50,11 +50,11 @@ InvalidParamsError  = function InvalidParamsError() {
     this.data    = Array.prototype.slice.call(arguments).splice();
 };
 
-util.inherits(JsonRpcError, Error);
-util.inherits(ParseError, JsonRpcError);
-util.inherits(InvalidRequestError, JsonRpcError);
-util.inherits(MethodNotFoundError, JsonRpcError);
-util.inherits(InvalidParamsError, JsonRpcError);
+inherits(JsonRpcError, Error);
+inherits(ParseError, JsonRpcError);
+inherits(InvalidRequestError, JsonRpcError);
+inherits(MethodNotFoundError, JsonRpcError);
+inherits(InvalidParamsError, JsonRpcError);
 
 module.exports = {
     JsonRpcError        : JsonRpcError,

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -1,8 +1,7 @@
 (function () { 'use strict';
 
-var exception, jsonrpc, util;
+var exception, jsonrpc;
 
-util      = require('util');
 exception = require('./exceptions');
 
 var isString = function(obj) {

--- a/package.json
+++ b/package.json
@@ -17,12 +17,15 @@
     "jsonrpc2"
   ],
   "engine": {
-    "node":">0.8.16"
+    "node": ">0.8.16"
   },
   "author": "Ruben LZ Tan",
   "license": "MIT",
   "devDependencies": {
     "chai": "~1.4.2",
     "mocha": "~1.8.1"
+  },
+  "dependencies": {
+    "inherits": "^2.0.1"
   }
 }


### PR DESCRIPTION
Hi! I want to use this package in browser but browserify uses whole 'util' shim which is too heavy. https://www.npmjs.com/package/inherits seems to be a good solution in this case.
