### PR TITLE
Methods that work with objects now check for errors

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -146,12 +146,33 @@ module.exports = jsonrpc = {
      *                  The names MUST match exactly, including case, to the 
      *                  method's expected parameters.
      * 
-     * @param  {String} id        
-     * @param  {String} method       
-     * @param  {Object|Array} params 
-     * @return {String} serialized version of the request object
+     * @param  {String} id
+     * @param  {String} method
+     * @param  {(Object|Array|Mixed)} params. Object params will be
+     *         used by-name. Array params will be used by-position. Anything
+     *         else will be used as an Array of one element.
+     * @return {(String|Array.<Error>)} serialized version of the request
+     *         object or array of errors
      */
     request : function (id, method, params) {
+        var req = this.requestObject(id, method, params);
+
+        if (isArray(req)) {
+            return req;
+        }
+
+        return JSON.stringify(req);
+    },
+
+    /**
+     * Creates a JSON-RPC 2.0 request object. 
+     *
+     * @param  {String} id        
+     * @param  {String} method       
+     * @param  {(Object|Array)} params
+     * @return {(Object|Array.<Error>)} request object or array of errors
+     */
+    requestObject : function (id, method, params) {
         // Make sure params is either an array or object
         if (params && !isObject(params) && !isArray(params)) {
             params = [params];
@@ -171,19 +192,7 @@ module.exports = jsonrpc = {
             return errors;
         }
 
-        return JSON.stringify(this.requestObject(id, method, params));
-    },
-
-    /**
-     * Creates a JSON-RPC 2.0 request object. 
-     *
-     * @param  {String} id        
-     * @param  {String} method       
-     * @param  {Object|Array} params 
-     * @return {Object} request object
-     */
-    requestObject : function (id, method, params) {
-        var req = { 
+        var req = {
             jsonrpc : '2.0',
             id      : id,
             method  : method
@@ -230,10 +239,28 @@ module.exports = jsonrpc = {
      *                  method's expected parameters.
      * 
      * @param  {String} method       
-     * @param  {Object|Array} params 
-     * @return {String} serialized version of the notification object
+     * @param  {(Object|Array)} params
+     * @return {(String|Array.<Error>)} serialized version of the notification
+     * object
      */
     notification : function (method, params) {
+        var not = this.notificationObject(method, params);
+
+        if (isArray(not)) {
+            return not;
+        }
+
+        return JSON.stringify(not);
+    },
+
+    /**
+     * Creates a JSON-RPC 2.0 notification object. 
+     *
+     * @param  {String} method       
+     * @param  {(Object|Array)} params
+     * @return {(Object|Array.<Error>)} notification object or array of errors
+     */
+    notificationObject : function (method, params) {      
         var errors = _validateMessageStructure('notification', {
             method : method,
             params : params
@@ -247,18 +274,7 @@ module.exports = jsonrpc = {
             return errors;
         }
 
-        return JSON.stringify(this.notificationObject(method, params));
-    },
-
-    /**
-     * Creates a JSON-RPC 2.0 notification object. 
-     *
-     * @param  {String} method       
-     * @param  {Object|Array} params 
-     * @return {Object} notification object
-     */
-    notificationObject : function (method, params) {      
-        var notification = { 
+        var notification = {
             jsonrpc : '2.0',
             method  : method
         };
@@ -294,9 +310,28 @@ module.exports = jsonrpc = {
      * 
      * @param  {String} id    
      * @param  {Mixed} result
-     * @return {String} serialized version of this response object
+     * @return {(String|Array.<Error>)} serialized version of this response
+     *         object or array of errors
      */
     success : function (id, result) {
+        var succ = this.successObject(id, result);
+
+        if (isArray(succ)) {
+            return succ;
+        }
+
+        return JSON.stringify(succ);
+    },
+
+    /**
+     * Creates a JSON-RPC 2.0 success response object. 
+     *
+     * @param  {String} id    
+     * @param  {Mixed} result
+     * @return {(Object|Array.<Error>)} success response object or array of
+     *         errors
+     */
+    successObject : function (id, result) {
         var errors = _validateMessageStructure('success', {
             id     : id,
             result : result
@@ -310,18 +345,7 @@ module.exports = jsonrpc = {
             return errors;
         }
 
-        return JSON.stringify(this.successObject(id, result));
-    },
-
-    /**
-     * Creates a JSON-RPC 2.0 success response object. 
-     *
-     * @param  {String} id    
-     * @param  {Mixed} result
-     * @return {Object} success response object
-     */
-    successObject : function (id, result) {
-        var success = { 
+        var success = {
             jsonrpc : '2.0',
             id      : id,
             result  : result
@@ -374,6 +398,24 @@ module.exports = jsonrpc = {
      * @return {String} serialized version of this response object
      */
     error : function (id, error) {
+        var err = this.errorObject(id, error);
+
+        if (isArray(err)) {
+            return err;
+        }
+
+        return JSON.stringify(err);
+    },
+
+    /**
+     * Creates a JSON-RPC 2.0 success response object. 
+     *
+     * @param  {String} id    
+     * @param  {Mixed} error
+     * @return {(Object|Array.<Error>)} error response object or array of
+     *         errors if supplied arguments are bad.
+     */
+    errorObject : function (id, error) {
         var errors = _validateMessageStructure('error', {
             id    : id,
             error : error
@@ -387,17 +429,6 @@ module.exports = jsonrpc = {
             return errors;
         }
 
-        return JSON.stringify(this.errorObject(id, error));
-    },
-
-    /**
-     * Creates a JSON-RPC 2.0 success response object. 
-     *
-     * @param  {String} id    
-     * @param  {Mixed} error
-     * @return {Object} error response object
-     */
-    errorObject : function (id, error) {
         var error = {
             jsonrpc : '2.0',
             id      : id,
@@ -413,12 +444,13 @@ module.exports = jsonrpc = {
      * success, or failure), and return its type and properly formatted object.
      * 
      * @param  {String} msg
-     * @return {Object} an object of this format:
+     * @return {(Object|Error)} an object of this format:
      *
      *  {
      *      type    : <Enum, request|notification|success|error>
      *      payload : <Object>
      *  }
+     * or Error if supplied msg could not be deserialized.
      */
     deserialize : function (msg) {
         var obj;
@@ -442,12 +474,13 @@ module.exports = jsonrpc = {
      * success, or failure), and return its type and properly formatted object.
      * 
      * @param  {Object} obj
-     * @return {Object} an object of this format:
+     * @return {Object|Error} an object of this format:
      *
      *  {
      *      type    : <Enum, request|notification|success|error>
      *      payload : <Object>
      *  }
+     * or Error if supplied obj could not be deserialized.
      */
     deserializeObject : function (obj) {
         // Check for jsonrpc


### PR DESCRIPTION
This is needed for browser JSONP transport that do not work with JSON format directly (id, name and params are stringified differently).
